### PR TITLE
[WarpBuild]: shift workflows to warp-ubuntu-latest-arm64-4x

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: 'Build (${{ matrix.os }}, Node ${{ matrix.node }})'
-    runs-on: ${{ matrix.os }}
+    runs-on: warp-ubuntu-latest-arm64-4x
     strategy:
       fail-fast: false
       matrix:
@@ -32,7 +32,7 @@ jobs:
 
   integration:
     name: 'Integration Tests (${{ matrix.os }}, Node ${{ matrix.node }})'
-    runs-on: ${{ matrix.os }}
+    runs-on: warp-ubuntu-latest-arm64-4x
     strategy:
       fail-fast: false
       matrix:
@@ -58,18 +58,21 @@ jobs:
         run: npm run test:integration
 
   e2e-simple:
+    runs-on: warp-ubuntu-latest-arm64-4x
     name: E2E Simple
     uses: ./.github/workflows/e2e-base.yml
     with:
       testScript: 'tasks/e2e-simple.sh'
 
   e2e-installs:
+    runs-on: warp-ubuntu-latest-arm64-4x
     name: E2E Installs
     uses: ./.github/workflows/e2e-base.yml
     with:
       testScript: 'tasks/e2e-installs.sh'
 
   e2e-kitchensink:
+    runs-on: warp-ubuntu-latest-arm64-4x
     name: E2E Kitchensink
     uses: ./.github/workflows/e2e-base.yml
     with:


### PR DESCRIPTION

## Ready to Warp! 🚀


> [!IMPORTANT]
> We noticed that this repository is public. Please make sure to allow WarpBuild runners to be used by public repositories:
> 1. Go to your organization's [default runner settings page](https://github.com/organizations/denispalnitskytest/settings/actions/runner-groups/1).
> 2. Check `Allow public repositories`.
>
> For more information, please refer our [documentation](https://docs.warpbuild.com/public-repos)


This PR was raised by WarpBuild to shift the following workflow(s) to the `warp-ubuntu-latest-arm64-4x` runner.

1. [Build & Test](https://github.com/denispalnitskytest/example-react/blob/main/.github/workflows/build-and-test.yml)

Please review the changes in this PR and merge when ready. You can see the status at your [dashboard](https://app.warpbuild.com).

> [!NOTE]
> **All** the jobs in the workflows are shifted to the chosen runner. If you want to shift only a few jobs, please change the values manually in the workflow files.
----
Switches to using fast runners provisioned on [warpbuild.com](https://warpbuild.com).
